### PR TITLE
Ignore . fields in data collector

### DIFF
--- a/src/bitExpert/PHPStan/Sylius/Collector/Grid/CollectFieldsForGridClass.php
+++ b/src/bitExpert/PHPStan/Sylius/Collector/Grid/CollectFieldsForGridClass.php
@@ -63,6 +63,11 @@ class CollectFieldsForGridClass extends AbstractGridClassCollector implements Co
         /** @var String_ $fieldName */
         $fieldName = $arg->value;
 
+        // the . means the resource object is passed to the grid field. That means, we can ignore it
+        if ('.' === $fieldName->value) {
+            return null;
+        }
+
         return [$classType->getClassName(), $fieldName->value, $node->getLine()];
     }
 }

--- a/tests/bitExpert/PHPStan/Sylius/Rule/Grid/GridBuilderFilterIsPartOfResourceClassUnitTest.php
+++ b/tests/bitExpert/PHPStan/Sylius/Rule/Grid/GridBuilderFilterIsPartOfResourceClassUnitTest.php
@@ -42,7 +42,7 @@ class GridBuilderFilterIsPartOfResourceClassUnitTest extends RuleTestCase
             [
                 [
                     'The filter field "name" needs to exists as property in resource class "App\Entity\Supplier".',
-                    44,
+                    47,
                 ],
             ],
         );

--- a/tests/bitExpert/PHPStan/Sylius/Rule/Grid/ResourceAwareGridNeedsResourceClassUnitTest.php
+++ b/tests/bitExpert/PHPStan/Sylius/Rule/Grid/ResourceAwareGridNeedsResourceClassUnitTest.php
@@ -32,7 +32,7 @@ class ResourceAwareGridNeedsResourceClassUnitTest extends RuleTestCase
             [
                 [
                     'getResourceClass() needs to provide a resource class. Mark "App\Entity\Supplier" with #[AsResource] attribute.',
-                    48,
+                    51,
                 ],
             ],
         );

--- a/tests/bitExpert/PHPStan/Sylius/Rule/Grid/data/grid.php
+++ b/tests/bitExpert/PHPStan/Sylius/Rule/Grid/data/grid.php
@@ -40,6 +40,9 @@ final class AdminSupplierGrid extends AbstractGrid implements ResourceAwareGridI
         $gridBuilder->addField(
             StringField::create('name')->setLabel('app.ui.name'),
         );
+        $gridBuilder->addField(
+            StringField::create('.')->setLabel('app.ui.some_calculated_field'),
+        );
         $gridBuilder->addFilter(
             Filter::create('name', 'string'),
         );


### PR DESCRIPTION
Passing a "." in the grid field definition has a special meaning: it indicates to use the resource object rather than a specific field. Therefore, we can exclude it from the data collector.